### PR TITLE
feat: 오류 코드 관리를 위한 BaseErrorCode 및 세부 ErrorCode 구현

### DIFF
--- a/src/main/java/com/market/core/code/BaseErrorCode.java
+++ b/src/main/java/com/market/core/code/BaseErrorCode.java
@@ -1,0 +1,11 @@
+package com.market.core.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+    int getErrorCode();
+
+    String getErrorMessage();
+
+    HttpStatus getStatus();
+}

--- a/src/main/java/com/market/core/code/BaseErrorCode.java
+++ b/src/main/java/com/market/core/code/BaseErrorCode.java
@@ -1,5 +1,6 @@
 package com.market.core.code;
 
+import com.market.core.response.ErrorResponse;
 import org.springframework.http.HttpStatus;
 
 public interface BaseErrorCode {
@@ -8,4 +9,6 @@ public interface BaseErrorCode {
     String getErrorMessage();
 
     HttpStatus getStatus();
+
+    ErrorResponse getErrorResponse();
 }

--- a/src/main/java/com/market/core/code/GlobalErrorCode.java
+++ b/src/main/java/com/market/core/code/GlobalErrorCode.java
@@ -5,15 +5,15 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum MemberErrorCode implements BaseErrorCode {
-    // 400 BAD_REQUEST
-    NOT_FOUND_MEMBER_EMAIL(400, "존재하지 않는 회원입니다.", HttpStatus.BAD_REQUEST);
+public enum GlobalErrorCode implements BaseErrorCode {
+    VALIDATION_FAILED(400, "입력 값이 유효하지 않습니다. 다시 확인해 주세요", HttpStatus.BAD_REQUEST),
+    INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final int errorCode;
     private final String errorMessage;
     private final HttpStatus status;
 
-    MemberErrorCode(int errorCode, String errorMessage, HttpStatus status) {
+    GlobalErrorCode(int errorCode, String errorMessage, HttpStatus status) {
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
         this.status = status;

--- a/src/main/java/com/market/core/code/JwtErrorCode.java
+++ b/src/main/java/com/market/core/code/JwtErrorCode.java
@@ -5,15 +5,16 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum MemberErrorCode implements BaseErrorCode {
-    // 400 BAD_REQUEST
-    NOT_FOUND_MEMBER_EMAIL(400, "존재하지 않는 회원입니다.", HttpStatus.BAD_REQUEST);
+public enum JwtErrorCode implements BaseErrorCode {
+    VALIDATION_TOKEN_FAILED(400, "유효하지 않은 토큰입니다.", HttpStatus.BAD_REQUEST),
+    VALIDATION_TOKEN_EXPIRED(401, "토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    VALIDATION_TOKEN_NOT_AUTHORIZATION(401, "접근 권한이 없습니다.", HttpStatus.UNAUTHORIZED);
 
     private final int errorCode;
     private final String errorMessage;
     private final HttpStatus status;
 
-    MemberErrorCode(int errorCode, String errorMessage, HttpStatus status) {
+    JwtErrorCode(int errorCode, String errorMessage, HttpStatus status) {
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
         this.status = status;

--- a/src/main/java/com/market/core/code/MemberErrorCode.java
+++ b/src/main/java/com/market/core/code/MemberErrorCode.java
@@ -1,0 +1,20 @@
+package com.market.core.code;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum MemberErrorCode implements BaseErrorCode {
+    // 400 BAD_REQUEST
+    NOT_FOUND_MEMBER_EMAIL(400, "존재하지 않는 회원입니다.", HttpStatus.BAD_REQUEST);
+
+    private final int errorCode;
+    private final String errorMessage;
+    private final HttpStatus status;
+
+    MemberErrorCode(int errorCode, String errorMessage, HttpStatus status) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/market/core/error/exception/security/MemberEmailNotFoundException.java
+++ b/src/main/java/com/market/core/error/exception/security/MemberEmailNotFoundException.java
@@ -1,0 +1,15 @@
+package com.market.core.error.exception.security;
+
+import com.market.core.code.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class MemberEmailNotFoundException extends RuntimeException {
+
+    private final BaseErrorCode errorCode;
+
+    public MemberEmailNotFoundException(BaseErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/market/core/response/ErrorResponse.java
+++ b/src/main/java/com/market/core/response/ErrorResponse.java
@@ -18,5 +18,4 @@ public class ErrorResponse {
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
     }
-
 }

--- a/src/main/java/com/market/core/security/SecurityConfig.java
+++ b/src/main/java/com/market/core/security/SecurityConfig.java
@@ -1,0 +1,183 @@
+package com.market.core.security;
+
+import com.market.member.entity.RolesType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
+
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    /**
+     * 패스워드 인코더
+     */
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    /**
+     * 로그인 인증 작업 처리
+     */
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    /**
+     * 공개 접근 필터 체인
+     */
+    @Bean
+    @Order(1)
+    public SecurityFilterChain publicFilterChain(HttpSecurity http) throws Exception {
+        defaultSecuritySetting(http);
+        http
+                .securityMatchers(matcher -> matcher
+                        .requestMatchers(publicRequestMatchers()))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(publicRequestMatchers()).permitAll()
+//                        TODO: endpoint 추가 후 주석 풀기
+//                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
+
+    /**
+     * 인증 및 권한이 필요한 필터 체인
+     */
+    @Bean
+    @Order(2)
+    public SecurityFilterChain authenticatedFilterChain(HttpSecurity http) throws Exception {
+        defaultSecuritySetting(http);
+        http
+                .securityMatchers(matcher -> matcher
+                        .requestMatchers(authenticatedRequestMatchers()))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(authenticatedRequestMatchers())
+                        .hasAnyAuthority(RolesType.ROLE_ADMIN.name(), RolesType.ROLE_USER.name(), RolesType.ROLE_STORE_OWNER.name())
+                        .anyRequest().authenticated());
+//                  TODO: 예외 처리, JWT Filter 추가
+//                .exceptionHandling(exception -> exception
+//                        .accessDeniedHandler())
+//                .addFilterBefore()
+
+        return http.build();
+    }
+
+    /**
+     * 공개 접근 endpoint
+     */
+    private RequestMatcher[] publicRequestMatchers() {
+        List<RequestMatcher> requestMatchers = List.of(
+//                TODO: endpoint 추가
+                antMatcher("/**")
+        );
+
+        return requestMatchers.toArray(RequestMatcher[]::new);
+    }
+
+    /**
+     * 인증 및 권한이 필요한 endpoint
+     */
+    private RequestMatcher[] authenticatedRequestMatchers() {
+        List<RequestMatcher> requestMatchers = List.of(
+//                TODO: endpoint 추가
+                antMatcher("/**")
+        );
+
+        return requestMatchers.toArray(RequestMatcher[]::new);
+    }
+
+    /**
+     * Spring Security 기본 설정 메서드
+     */
+    private void defaultSecuritySetting(HttpSecurity http) throws Exception {
+        http
+                // JWT, OAuth 기반
+                .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 비활성화
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .formLogin(AbstractHttpConfigurer::disable) // Form 기반 로그인 비활성화
+                .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
+                .rememberMe(AbstractHttpConfigurer::disable) // 세션 기반의 인증 비활성화
+                .logout(AbstractHttpConfigurer::disable) // 로그아웃 기능 비활성화
+                .anonymous(AbstractHttpConfigurer::disable) // 익명 사용자 접근 비할성화
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 생성하지 않음
+                .headers(headers -> headers.frameOptions(
+                        HeadersConfigurer.FrameOptionsConfig::disable) // X-Frame-Options 헤더 비활성화, 클릭재킹 공격 방지
+                );
+    }
+
+    /**
+     * CORS 설정
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        // 허용할 Origin(출처)
+        configuration.setAllowedOrigins(
+                Arrays.asList(
+                        "http://localhost:8080",
+                        "http://127.0.0.1:8080",
+                        "http://localhost:8080/swagger-ui.html",
+                        "http://127.0.0.1:8080/swagger-ui.html"
+                )
+        );
+
+        // 허용할 HTTP 메서드
+        configuration.setAllowedMethods(
+                Arrays.asList(
+                        "GET",
+                        "POST",
+                        "PUT",
+                        "PATCH",
+                        "DELETE"
+                )
+        );
+
+        // 허용할 헤더
+        configuration.setAllowedHeaders(
+                Arrays.asList(
+                        "Authorization",
+                        "Cache-Control",
+                        "Content-Type",
+                        "X-Requested-With"
+                )
+        );
+
+        // 인증 정보(쿠키, Authorization 헤더 등)를 포함한 요청 허용
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration); // 모든 경로에 대해 CORS 설정 적용
+
+        return source;
+    }
+}

--- a/src/main/java/com/market/core/security/service/PrincipalDetails.java
+++ b/src/main/java/com/market/core/security/service/PrincipalDetails.java
@@ -1,0 +1,71 @@
+package com.market.core.security.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.market.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PrincipalDetails implements UserDetails {
+
+    private final long id;
+    private final String email;
+    @JsonIgnore
+    private final String password;
+    private final List<GrantedAuthority> authorities;
+
+    // 생성자
+    public PrincipalDetails(Member member) {
+        this.id = member.getId();
+        this.email = member.getEmail();
+        this.password = member.getPassword();
+        this.authorities = Optional.ofNullable(member.getRoles())
+                .map(role -> List.<GrantedAuthority>of(new SimpleGrantedAuthority(role.name())))
+                .orElse(List.of());
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities; // 권한 리스트 반환
+    }
+
+    @Override
+    public String getPassword() {
+        return password; // 사용자 비밀번호 반환
+    }
+
+    @Override
+    public String getUsername() {
+        return email; // 사용자 이메일 반환
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true; // 계정 만료 여부
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true; // 계정 잠김 여부
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true; // 자격 증명 만료 여부
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true; // 계정 활성화 여부
+    }
+}

--- a/src/main/java/com/market/core/security/service/PrincipalDetailsService.java
+++ b/src/main/java/com/market/core/security/service/PrincipalDetailsService.java
@@ -1,0 +1,26 @@
+package com.market.core.security.service;
+
+import com.market.core.code.MemberErrorCode;
+import com.market.core.error.exception.security.MemberEmailNotFoundException;
+import com.market.member.entity.Member;
+import com.market.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PrincipalDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberEmailNotFoundException(MemberErrorCode.NOT_FOUND_MEMBER_EMAIL));
+
+        return new PrincipalDetails(member);
+    }
+}

--- a/src/main/java/com/market/member/entity/Member.java
+++ b/src/main/java/com/market/member/entity/Member.java
@@ -1,0 +1,20 @@
+package com.market.member.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Member {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name; // 이름
+
+    private String email; // 이메일
+
+    private String password; // 비밀번호
+
+    @Enumerated(EnumType.STRING)
+    private RolesType roles = RolesType.ROLE_USER; // 권한
+}

--- a/src/main/java/com/market/member/entity/RolesType.java
+++ b/src/main/java/com/market/member/entity/RolesType.java
@@ -1,0 +1,7 @@
+package com.market.member.entity;
+
+public enum RolesType {
+    ROLE_ADMIN, // 관리자
+    ROLE_USER, // 일반 회원
+    ROLE_STORE_OWNER; // 가게 회원
+}

--- a/src/main/java/com/market/member/repository/MemberRepository.java
+++ b/src/main/java/com/market/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.market.member.repository;
+
+import com.market.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    public Optional<Member> findByEmail(String email);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

 resolves: #12

## 📝작업 내용

- BaseErrorCode 인터페이스에 getErrorResponse() 메서드를 추가했습니다.
- 공통 오류 코드를 관리하기 위해 GlobalErrorCode를 구현했습니다.
- JWT 관련 오류 처리를 위한 JwtErrorCode를 구현했습니다.
- Member 엔티티와 관련된 오류 처리를 위한 MemberErrorCode를 구현했습니다.

## 💬리뷰 요구사항

현재 ErrorCode 구현은 이전 레포지토리의 형태를 참고하여 작성했는데, 이 방식을 그대로 사용하는 것이 최선인지에 대해 논의가 필요합니다.